### PR TITLE
#5 - Only upload supported file types

### DIFF
--- a/flickr_cli.py
+++ b/flickr_cli.py
@@ -108,7 +108,9 @@ class directoryFlickrUpload(abstractDirectoryUpload):
 
     def valid_img(self, f):
         try:
-            if imghdr.what(f):
+            file_type = imghdr.what(f)
+            supported_types = ['jpeg', 'gif', 'png']
+            if file_type in supported_types:
                 return True
         except:
             pass


### PR DESCRIPTION
Ultimately it would be best to put the types in the configuration file.
